### PR TITLE
Fix inventoryitem bag rent availability check

### DIFF
--- a/classes/inventoryitem.lua
+++ b/classes/inventoryitem.lua
@@ -57,8 +57,8 @@ function CInventoryItem:update()
 	end
 
 	-- Check if not rented
-	if self.SlotNumber > 120 then
-		page = 3 + math.floor((self.SlotNumber - 121) / 30)
+	if self.SlotNumber > 119 then
+		page = 3 + math.floor((self.SlotNumber - 120) / 30)
 		self.Available = self:isPageAvailable(page)
 	else
 		self.Available = true


### PR DESCRIPTION
Caused by off-by-one error as this specific array starts at 0 instead of Lua's typical 1